### PR TITLE
Change API for nested actions and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ for org in c.org.get()['results']:
 
 ```
 
+You can also call nested resources/actions like this:
+
+```
+# /api/v1/org/
+for org in c.org.get()['results']:
+   # /api/v1/org/<slug>/projects
+   org_projects = c.org(org['slug']).projects.get()
+
+```
+
 ### Getting Stream Data
 
 You can use `StreamData` to easily download all or partial stream data.

--- a/README.md
+++ b/README.md
@@ -61,19 +61,44 @@ if ok:
 
 The Api() can be used to access any of the APIs in https://iotile.cloud/api/v1/
 
-For example, say you want to get a list of Organizations or a given Organization
-via the https://iotile.cloud/api/v1/org/ API. You can simply:
+The Api() is generic and therefore will support any future resources supported by the IoTile Cloud Rest API.
 
 ```
-# After calling c.login() or c.set_token()
+from iotile_cloud.api.connection import Api
 
-# Get list of all organizations
-my_organizations = c.org.get()
-for org in my_organizations['results']:
-   print(str(org)
-   
-# Get a single organization
-org = c.org('my-org-slug').get()
+api = Api()
+ok = api.login(email='user@example.com', password='my.pass')
+
+## GET http://iotile.cloud/api/v1/project/
+##     Note: Any kwargs passed to get(), post(), put(), delete() will be used as url parameters
+api.org.get()
+
+## POST http://iotile.cloud/api/v1/org/
+new = api.org.post({"name": "My new Org"})
+
+## PUT http://iotile.cloud/api/v1/org/{slug}/
+api.org(new["slug"]).put({"about": "About Org"})
+
+PATCH http://iotile.cloud/api/v1/org/{slug}/
+api.org(new["slug"]).patch({"about": "About new Org"})
+
+## GET http://iotile.cloud/api/v1/org/{slug}/
+api.org(new["slug"]).get()
+
+## DELETE http://iotile.cloud/api/v1/org/{slug}/
+## NOTE: Not all resources can be deleted by users
+api.org(new["slug"]).delete()
+```
+
+You can pass arguments to any get using
+
+```
+# /api/v1/org/
+for org in c.org.get()['results']:
+   # Pass any arguments as get(foo=1, bar='2'). e.g.
+   # /api/v1/project/?org__slug=<slug>
+   org_projects = c.project.get(org__slug='{0}'.format(org['slug']))
+
 ```
 
 ### Getting Stream Data

--- a/example.py
+++ b/example.py
@@ -5,6 +5,7 @@ import sys
 
 from iotile_cloud.api.connection import Api
 from iotile_cloud.stream.data import StreamData
+from iotile_cloud.api.exceptions import HttpNotFoundError
 
 from logging import StreamHandler, Formatter
 
@@ -21,7 +22,6 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('-u', '--user', dest='email', type=str, help='Email used for login')
 
 parser.add_argument('--id', dest='stream_id', type=str, help='ID of stream definition to get')
-parser.add_argument('--lastn', dest='lastn', type=int, help='Number of Entries')
 
 args = parser.parse_args()
 logger.info('--------------')
@@ -41,7 +41,7 @@ if ok:
     my_organizations = c.org.get()
     for org in my_organizations['results']:
         logger.info('I am a member of {0}'.format(org['name']))
-        org_projects = c.project.get(org__slug='{0}'.format(org['slug']))
+        org_projects = c.org(org['slug']).projects.get()
         for proj in org_projects['results']:
             logger.info(' --> Project: {0}'.format(proj['name']))
 
@@ -49,7 +49,10 @@ if ok:
 
     if args.stream_id:
         stream_data = StreamData(args.stream_id, c)
-        stream_data.initialize_from_server(lastn=100)
+        try:
+            stream_data.initialize_from_server(lastn=100)
+        except HttpNotFoundError as e:
+            logger.error(e)
         for item in stream_data.data:
             logger.info('{0}: {1}'.format(item['timestamp'], item['value']))
 

--- a/example.py
+++ b/example.py
@@ -41,7 +41,7 @@ if ok:
     my_organizations = c.org.get()
     for org in my_organizations['results']:
         logger.info('I am a member of {0}'.format(org['name']))
-        org_projects = c.project.get(extra='org__slug={0}'.format(org['slug']))
+        org_projects = c.project.get(org__slug='{0}'.format(org['slug']))
         for proj in org_projects['results']:
             logger.info(' --> Project: {0}'.format(proj['name']))
 

--- a/iotile_cloud/api/connection.py
+++ b/iotile_cloud/api/connection.py
@@ -108,10 +108,8 @@ class RestResource(object):
         else:
             return  # @@@ We should probably do some sort of error here? (Is this even possible?)
 
-    def url(self, args=None):
+    def url(self):
         url = self._store["base_url"]
-        if args:
-            url += '?{0}'.format(args)
         return url
 
     def _get_header(self):
@@ -125,10 +123,7 @@ class RestResource(object):
         return headers
 
     def get(self, **kwargs):
-        args = None
-        if 'extra' in kwargs:
-            args = kwargs['extra']
-        resp = requests.get(self.url(args), headers=self._get_header())
+        resp = requests.get(self.url(), headers=self._get_header(), params=kwargs)
         return self._process_response(resp)
 
     def post(self, data=None, **kwargs):
@@ -137,7 +132,7 @@ class RestResource(object):
         else:
             payload = None
 
-        resp = requests.post(self.url(), data=payload, headers=self._get_header())
+        resp = requests.post(self.url(), data=payload, headers=self._get_header(),)
         return self._process_response(resp)
 
     def patch(self, data=None, **kwargs):
@@ -168,7 +163,7 @@ class RestResource(object):
         else:
             return False
 
-    def upload_file(self, filename, mode='rb', extra=None, **kwargs):
+    def upload_file(self, filename, mode='rb', **kwargs):
         try:
             payload = {
                 'file': open(filename, mode)
@@ -179,8 +174,8 @@ class RestResource(object):
         headers = {}
         authorization_str = '{0} {1}'.format(self._store['token_type'], self._store["token"])
         headers['Authorization'] = authorization_str
-        logger.debug('Uploading file to {}'.format(self.url(extra)))
-        resp = requests.post(self.url(extra), files=payload, headers=headers)
+        logger.debug('Uploading file to {}'.format(str(kwargs)))
+        resp = requests.post(self.url(), files=payload, headers=headers, params=kwargs)
         return self._process_response(resp)
 
 

--- a/iotile_cloud/stream/data.py
+++ b/iotile_cloud/stream/data.py
@@ -16,17 +16,18 @@ class StreamData(object):
         self.stream_id = stream_id
         self.api = api
 
-    def format_extra(self, page, start=None, end=None, lastn=None):
-        parts = ['page={0}'.format(page),]
+    def _get_args_dict(self, page, start=None, end=None, lastn=None):
+        parts = {}
+        parts['page'] = page
         if start:
-            parts.append('start={0}'.format(start))
+            parts['start']='{0}'.format(start)
         if end:
-            parts.append('end={0}'.format(end))
+            parts['end']='{0}'.format(end)
         if lastn:
-            parts.append('lastn={0}'.format(lastn))
-        return '&'.join(parts)
+            parts['lastn']='{0}'.format(lastn)
+        return parts
 
-    def date_format(self, timestamp):
+    def _date_format(self, timestamp):
         try:
             dt = dateutil.parser.parse(timestamp)
             return dt
@@ -38,14 +39,14 @@ class StreamData(object):
         logger.info('Downloading data for {0}'.format(self.stream_id))
         page = 1
         while page:
-            extra = self.format_extra(start=start, end=end, lastn=lastn, page=page)
+            extra = self._get_args_dict(start=start, end=end, lastn=lastn, page=page)
             logger.debug('{0} ===> Downloading: {1}'.format(page, extra))
-            raw_data = self.api.stream(self.stream_id, action='data').get(extra=extra)
+            raw_data = self.api.stream(self.stream_id, action='data').get(**extra)
             for item in raw_data['results']:
                 if not item['display_value']:
                     item['display_value'] = 0
                 self.data.append({
-                    'timestamp': self.date_format(item['timestamp']),
+                    'timestamp': self._date_format(item['timestamp']),
                     'value': item['display_value']
                 })
             if raw_data['next']:

--- a/iotile_cloud/stream/data.py
+++ b/iotile_cloud/stream/data.py
@@ -41,7 +41,7 @@ class StreamData(object):
         while page:
             extra = self._get_args_dict(start=start, end=end, lastn=lastn, page=page)
             logger.debug('{0} ===> Downloading: {1}'.format(page, extra))
-            raw_data = self.api.stream(self.stream_id, action='data').get(**extra)
+            raw_data = self.api.stream(self.stream_id).data.get(**extra)
             for item in raw_data['results']:
                 if not item['display_value']:
                     item['display_value'] = 0

--- a/tests/api.py
+++ b/tests/api.py
@@ -90,9 +90,9 @@ class ApiTestCase(unittest.TestCase):
         m.get('http://iotile.test/api/v1/test/my-detail/action/', text=json.dumps(payload))
 
         api = Api(domain='http://iotile.test')
-        resp = api.test('my-detail', action='action').url()
+        resp = api.test('my-detail').action.url()
         self.assertEqual(resp, 'http://iotile.test/api/v1/test/my-detail/action/')
-        resp = api.test('my-detail', action='action').get()
+        resp = api.test('my-detail').action.get()
         self.assertEqual(resp, {'a': 'b', 'c': 'd'})
 
     @requests_mock.Mocker()

--- a/tests/api.py
+++ b/tests/api.py
@@ -104,9 +104,7 @@ class ApiTestCase(unittest.TestCase):
         m.get('http://iotile.test/api/v1/test/my-detail/', text=json.dumps(payload))
 
         api = Api(domain='http://iotile.test')
-        resp = api.test('my-detail').url(args='foo=bar')
-        self.assertEqual(resp, 'http://iotile.test/api/v1/test/my-detail/?foo=bar')
-        resp = api.test('my-detail').get(extra='foo=bar')
+        resp = api.test('my-detail').get(foo='bar')
         self.assertEqual(resp, {'a': 'b', 'c': 'd'})
 
     @requests_mock.Mocker()

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -21,8 +21,6 @@ class ResourceTestCase(unittest.TestCase):
 
         url = self.base_resource.url()
         self.assertEqual(url, 'http://iotile.test/api/v1/test/')
-        url = self.base_resource.url(args='foo=bar')
-        self.assertEqual(url, 'http://iotile.test/api/v1/test/?foo=bar')
 
     def test_headers(self):
         expected_headers = {


### PR DESCRIPTION
- Arguments are now passed with the `get()` function using kwargs
- Actions (or nested resources) are now passed using `api.resource().action.get()`