### PR TITLE
Add Api.refresh_token()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 python:
 - '2.7'
 - '3.4'
+- '3.6'
 install:
 - pip install --upgrade tox-travis -r requirements-build.txt -r requirements-test.txt
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v0.5.1 (2017-05-10)
+
+  * Add Api function to refresh token
+  
+### v0.5.0 (2017-05-10)
+
+  * Add Api function to refresh token
+  
 ### v0.4.3 (2017-02-05)
 
   * Add python-dateutil dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
   * Add Api function to refresh token
   
-### v0.5.0 (2017-05-10)
+### v0.5.0 (2017-02-06)
 
-  * Add Api function to refresh token
+  * Changes to API to better handle nested resource actions and API arguments.
+     * Old: api.org(action='projects').get(extra='a=1&b=2')
+     * New api.org().projects.get(a=1, b=2)
   
 ### v0.4.3 (2017-02-05)
 

--- a/iotile_cloud/api/connection.py
+++ b/iotile_cloud/api/connection.py
@@ -253,6 +253,28 @@ class Api(object):
         else:
             logger.error('Logout failed: ' + str(r.status_code) + ' ' + r.content.decode())
 
+    def refresh_token(self):
+        """
+        Refresh JWT token
+        
+        :return: True if token was refreshed. False otherwise 
+        """
+        url = '{0}/{1}'.format(self.base_url, 'auth/api-jwt-refresh/')
+
+        r = requests.post(url, data={'token': self.token}, headers=DEFAULT_HEADERS)
+        if r.status_code == 200:
+            content = json.loads(r.content.decode())
+            if 'token' in content:
+                self.token = content['token']
+
+                logger.info('Token refreshed')
+                return True
+
+        logger.error('Token refresh failed: ' + str(r.status_code) + ' ' + r.content.decode())
+        self.token = None
+        return False
+
+
     def __getattr__(self, item):
         """
         Instead of raising an attribute error, the undefined attribute will

--- a/tests/api.py
+++ b/tests/api.py
@@ -57,6 +57,18 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(api.username, None)
         self.assertEqual(api.token, None)
 
+    @requests_mock.Mocker()
+    def test_token_refresh(self, m):
+        payload = {
+            'token': 'new-token'
+        }
+        m.post('http://iotile.test/api/v1/auth/api-jwt-refresh/', text=json.dumps(payload))
+
+        api = Api(domain='http://iotile.test')
+        api.set_token('old-token')
+        self.assertEqual(api.token, 'old-token')
+        api.refresh_token()
+        self.assertEqual(api.token, 'new-token')
 
     @requests_mock.Mocker()
     def test_get_list(self, m):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py27, py34, py36
 
 [testenv]
 deps =

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-version = '0.5.0'
+version = '0.5.1'


### PR DESCRIPTION
To make it easy to refresh the JWT token and avoid having to re-login
Fixes #2 