### PR TITLE
Fix python 3 msgpack unicode handling in mock_cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v0.9.4 (2018-06-26)
+
+  * Fix msgpack decoding on python 3.  It should pass raw=False to properly
+    decode string keys as unicode objects.
+
 ### v0.9.3 (2018-05-27)
 
   * Enhance upload_file to accept a data payload on top of the file for a

--- a/iotile_cloud/utils/mock_cloud.py
+++ b/iotile_cloud/utils/mock_cloud.py
@@ -228,7 +228,7 @@ class MockIOTileCloud(object):
                 self.logger.error("python-msgpack not installed, cannot parse message pack report")
                 return {'count': 0}
 
-            report = msgpack.unpackb(indata)
+            report = msgpack.unpackb(indata, raw=False)
 
             fmt = report.get('format')
 

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-version = '0.9.3'
+version = '0.9.4'


### PR DESCRIPTION
This PR fixes `mock_cloud` on python 3 to have the same unicode handling settings as `coretools` so that tests pass on python 3 when uploading msgpack encoded reports using `iotile-ext-cloud`.

Closes #46 
