### PR TITLE
Fix: couldn't log in more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+### v0.9.9 (2018-12-13)
+
+  * Fix login. It is now possible to log in after logout.
+
 ### v0.9.8 (2018-11-08)
 
   * mock hooks updated for OTA
-
 
 ### v0.9.7 (2018-10-29)
 

--- a/iotile_cloud/api/connection.py
+++ b/iotile_cloud/api/connection.py
@@ -139,9 +139,9 @@ class RestResource(object):
         return url
 
     def _get_header(self):
-        headers = DEFAULT_HEADERS
+        headers = DEFAULT_HEADERS.copy()
         if self._store['use_token']:
-            if not "token" in self._store:
+            if "token" not in self._store:
                 raise RestBaseException('No Token')
             authorization_str = '{0} {1}'.format(self._store['token_type'], self._store["token"])
             headers['Authorization'] = authorization_str
@@ -179,7 +179,7 @@ class RestResource(object):
 
         try:
             resp = requests.patch(
-                self.url(), data=payload, headers=self._get_header(),params=kwargs,  verify=self._store['verify']
+                self.url(), data=payload, headers=self._get_header(), params=kwargs, verify=self._store['verify']
             )
         except requests.exceptions.SSLError as err:
             raise HttpCouldNotVerifyServerError("Could not verify the server's SSL certificate", err)
@@ -299,7 +299,7 @@ class Api(object):
 
     def logout(self):
         url = '{0}/{1}'.format(self.base_url, 'auth/logout/')
-        headers = DEFAULT_HEADERS
+        headers = DEFAULT_HEADERS.copy()
         headers['Authorization'] = '{0} {1}'.format(self.token_type, self.token)
 
         try:
@@ -317,8 +317,8 @@ class Api(object):
     def refresh_token(self):
         """
         Refresh JWT token
-        
-        :return: True if token was refreshed. False otherwise 
+
+        :return: True if token was refreshed. False otherwise
         """
         assert self.token_type == DEFAULT_TOKEN_TYPE
         url = '{0}/{1}'.format(self.base_url, 'auth/api-jwt-refresh/')
@@ -341,7 +341,6 @@ class Api(object):
         logger.error('Token refresh failed: ' + str(r.status_code) + ' ' + r.content.decode())
         self.token = None
         return False
-
 
     def __getattr__(self, item):
         """

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-version = '0.9.8'
+version = '0.9.9'


### PR DESCRIPTION
Fixes #54 (and some formatting)

An _'Authorization'_ key was added to `DEFAULT_HEADERS` so it was used by the `login` method after the first call.